### PR TITLE
Finish packaging/availability for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Angular directive for rich text editor Quill",
   "author": "Bengt Weiße <bengtler@gmail.com>",
   "homepage": "https://github.com/KillerCodeMonkey/ngQuill",
+  "main": "src/ng-quill.js",
   "devDependencies": {
     "grunt": "~0.4.3",
     "grunt-contrib-uglify": "~0.6.0"


### PR DESCRIPTION
Without main: setting - Babel/ES6 import, Browserify require() etc will look for ./index.js in the package.