### PR TITLE
Adds a callback function on the scope of the directive

### DIFF
--- a/src/ng-quill.js
+++ b/src/ng-quill.js
@@ -131,7 +131,8 @@
                     'required': '@?editorRequired',
                     'readOnly': '&?',
                     'errorClass': '@?',
-                    'ngModel': '='
+                    'ngModel': '=',
+                    'callback': '='
                 },
                 require: 'ngModel',
                 restrict: 'E',
@@ -236,6 +237,9 @@
                     // provide event to get recognized when editor is created -> pass editor object.
                     $timeout(function(){
                        $scope.$emit('editorCreated', editor);
+                       if($scope.callback) {
+                          $scope.callback(editor);
+                       }
                     });
 
                     var updateFromPlugin = false;


### PR DESCRIPTION
Why: When displaying multiple editors on a page, we need to know which editor we're modifying.

What: Exposes a callback function on the scope of the directive. Once the editor is ready, the callback is called with the editor object, so that it can be consumed and modified.